### PR TITLE
feat: balance GitHub App and CLI messaging across site

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,6 +8,7 @@ const Footer = () => {
       { name: "Documentation", href: "/doc" },
       { name: "Status", href: "/status" },
       { name: "GitHub App", href: "https://github.com/apps/flowlint" },
+      { name: "CLI", href: "/cli" },
     ],
     company: [
       { name: "About", href: "/" },

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -59,7 +59,7 @@ const Home = () => {
           <div className="container mx-auto max-w-6xl">
             <div className="text-center space-y-8">
               <Badge variant="secondary" className="mb-4">
-                GitHub App for n8n Workflows
+                Automated Static Analysis for n8n Workflows
               </Badge>
               <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-foreground">
                 Automated Static Analysis
@@ -77,9 +77,12 @@ const Home = () => {
                   </a>
                 </Button>
                 <Button size="lg" variant="outline" asChild>
-                  <a href="/doc">View Documentation</a>
+                  <a href="/cli">Try CLI</a>
                 </Button>
               </div>
+              <p className="text-sm text-muted-foreground mt-4">
+                Both integrate seamlessly with your workflow
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
Rebalanced the website to equally promote both GitHub App and CLI approaches. Previously, the site was exclusively oriented toward GitHub App, missing an opportunity to showcase the CLI as a valuable alternative for local development.

## Changes Made

### Home Page Hero Section
- **Badge**: Changed from "GitHub App for n8n Workflows" → "Automated Static Analysis for n8n Workflows" (neutral, technology-agnostic)
- **Primary CTA**: "Install GitHub App" (kept as first option for CI/CD teams)
- **Secondary CTA**: Changed from "View Documentation" → "Try CLI" (links to /cli page with full documentation)
- **Supporting Text**: Added "Both integrate seamlessly with your workflow" to clarify they're complementary tools

### Footer
- Added "CLI" link to Product section (alongside GitHub App, Documentation, Status)
- Provides equal discoverability for both approaches from the footer

## User Benefits
Now visitors can:
- **Choose GitHub App** for automatic PR checks in CI/CD workflows
- **Choose CLI** for local validation before pushing, in pre-commit hooks, or non-GitHub platforms

Both options are equally visible from key entry points (home hero and footer).

## Test Plan
- [x] Visit homepage and verify:
  - Badge text changed to neutral wording
  - Two CTA buttons visible side-by-side
  - Supporting text appears below CTAs
- [x] Click "Try CLI" button → should navigate to /cli page
- [x] Click "Install GitHub App" → should open GitHub app page
- [x] Verify Footer Product section has CLI link
- [x] Check mobile responsiveness (flex-col on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>