### PR TITLE
Update roadmap: Split CLI into shipped and in-progress items

### DIFF
--- a/src/data/roadmap.json
+++ b/src/data/roadmap.json
@@ -20,6 +20,10 @@
         {
           "title": "E2E Tests & Documentation",
           "description": "Complete end-to-end test suite, OpenAPI documentation, and distributed tracing implementation."
+        },
+        {
+          "title": "CLI Tool (Basic)",
+          "description": "Command-line interface with scan command, JSON output, config file support, and CI/CD integration via exit codes."
         }
       ]
     },
@@ -29,8 +33,8 @@
       "quarter": "Q4 2025",
       "items": [
         {
-          "title": "CLI Tool",
-          "description": "Command-line interface for local workflow linting and CI/CD integration with SARIF/JUnit output formats.",
+          "title": "Advanced Output Formats",
+          "description": "SARIF, JUnit XML, and GitHub Actions output formats for CLI tool to integrate with code scanning tools and CI/CD pipelines.",
           "estimatedCompletion": "Q4 2025"
         }
       ]


### PR DESCRIPTION
## Summary

Clarifies current CLI Tool status on public roadmap by splitting it into two items to reflect actual implementation.

## Problem

Current roadmap shows "CLI Tool" as "In Progress" which is misleading:
- Basic CLI **already exists** (v0.3.7, published to npm)
- Only SARIF/JUnit output formats are pending

## Solution

Split CLI into accurate status categories:

### Shipped ✅ (moved to "Shipped Features")
**CLI Tool (Basic)**
- `flowlint scan` command
- JSON output format
- Config file support (`.flowlint.yml`)
- CI/CD integration via exit codes (`--fail-on-error`)

### In Progress 🚧 (stays in "In Progress")
**Advanced Output Formats**
- SARIF format (for GitHub Code Scanning, VS Code)
- JUnit XML (for Jenkins, GitLab CI, CircleCI)
- GitHub Actions format (native annotations)

## Benefits

✅ Accurate roadmap - shows what's actually done vs. pending
✅ Clearer expectations - users know CLI exists, SARIF/JUnit is coming
✅ Better communication - reflects real implementation status

## Testing

- ✅ Build passes
- ✅ JSON structure valid
- ✅ Roadmap page renders correctly

## Related

- CLI package: `apps/cli` (v0.3.7)
- Next: GitHub issue for SARIF/JUnit implementation