### PR TITLE
docs: Add R14 Retry-After compliance to documentation

### DIFF
--- a/src/data/roadmap.json
+++ b/src/data/roadmap.json
@@ -6,8 +6,8 @@
       "title": "Shipped Features",
       "items": [
         {
-          "title": "R1-R13 Lint Rules",
-          "description": "Complete set of 13 production-ready linting rules for n8n workflows, covering rate limiting, error handling, secrets detection, webhook acknowledgment, and more."
+          "title": "R1-R14 Lint Rules",
+          "description": "Complete set of 14 production-ready linting rules for n8n workflows, covering rate limiting, error handling, secrets detection, webhook acknowledgment, Retry-After compliance, and more."
         },
         {
           "title": "GitHub App Integration",
@@ -30,13 +30,8 @@
     {
       "status": "in-progress",
       "title": "In Progress",
-      "quarter": "Q4 2025",
-      "items": [
-        {
-          "title": "R14: Retry-After Compliance",
-          "description": "Validate proper handling of HTTP 429 (Too Many Requests) and Retry-After headers with provider-aware retry templates."
-        }
-      ]
+      "quarter": "Q1 2026",
+      "items": []
     },
     {
       "status": "planned",

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -84,6 +84,12 @@ const Documentation = () => {
       description: "Detects webhooks performing heavy processing without immediate acknowledgment.",
       details: "Prevents timeout and duplicate events by requiring 'Respond to Webhook' node before heavy operations (HTTP requests, database queries, AI/LLM calls).",
     },
+    {
+      name: "retry_after_compliance",
+      severity: "should",
+      description: "Detects HTTP nodes with retry logic that ignore Retry-After headers from 429/503 responses.",
+      details: "APIs return Retry-After headers (seconds or HTTP date) to indicate when to retry. Ignoring these causes aggressive retry storms, wasted attempts, and potential API bans. Respecting server guidance prevents IP blocking and extended backoffs.",
+    },
   ];
 
   return (


### PR DESCRIPTION
## Summary

Updates FlowLint web documentation for **R14: HTTP Retry-After header compliance** rule.

## Changes

- ✅ Added  to Documentation.tsx implemented rules list
- ✅ Updated roadmap.json: R1-R13 → R1-R14 (14 production-ready rules)
- ✅ Moved R14 from 'In Progress' to 'Shipped Features'

## Rule Details

**Name:** retry_after_compliance
**Severity:** should (warning)
**Description:** Detects HTTP nodes with retry logic that ignore Retry-After headers from 429/503 responses.
**Impact:** Prevents API bans by respecting server rate limit guidance

## Related

- flowlint-app PR #150 (implementation)
- flowlint-app PR #151 (version bump)
- flowlint-app Issue #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)