### PR TITLE
fix(content): rename Web Validator to Web Linter

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ const Footer = () => {
     product: [
       { name: "Documentation", href: "/doc" },
       { name: "Roadmap", href: "/roadmap" },
-      { name: "Web Validator", href: "https://app.flowlint.dev" },
+      { name: "Web Linter", href: "https://app.flowlint.dev" },
       { name: "GitHub App", href: "/github-app" },
       { name: "CLI", href: "/cli" },
       { name: "Chrome Extension", href: "/chrome-extension" },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -50,7 +50,7 @@ const Header = () => {
       icon: GitPullRequest,
     },
     {
-      title: "Web Validator",
+      title: "Web Linter",
       href: "https://app.flowlint.dev",
       description: "Online linter for quick checks (Alpha).",
       icon: Globe,
@@ -168,7 +168,7 @@ const Header = () => {
 
             <Button asChild variant="default" size="sm" className="hidden lg:flex bg-primary hover:bg-primary/90 text-white border-0">
               <a href="https://app.flowlint.dev" target="_blank" rel="noopener noreferrer">
-                Try Web Validator <Badge variant="secondary" className="ml-2 text-[10px] h-5 px-1.5 bg-white/20 text-white">NEW</Badge>
+                Try Web Linter <Badge variant="secondary" className="ml-2 text-[10px] h-5 px-1.5 bg-white/20 text-white">NEW</Badge>
               </a>
             </Button>
           </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,7 +36,7 @@ const Home = () => {
       variant: "outline" as const
     },
     {
-      title: "Web Validator",
+      title: "Web Linter",
       icon: Globe,
       description: "Quick online checker. Copy & paste your workflow JSON to validate instantly without installation.",
       link: "https://app.flowlint.dev",


### PR DESCRIPTION
Unifies terminology across the ecosystem by renaming Web Validator to Web Linter.