### PR TITLE
fix(web): correct terms of service link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer = () => {
     ],
     legal: [
       { name: "Privacy Policy", href: "/privacy" },
-      { name: "Terms of Service", href: "/tos" },
+      { name: "Terms of Service", href: "/terms" },
     ],
   };
 


### PR DESCRIPTION
Changes the Terms of Service link in the footer from /tos to /terms for consistency with the actual page path.