### PR TITLE
fix(web): revert Terms of Service link to /tos

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer = () => {
     ],
     legal: [
       { name: "Privacy Policy", href: "/privacy" },
-      { name: "Terms of Service", href: "/terms" },
+      { name: "Terms of Service", href: "/tos" },
     ],
   };
 


### PR DESCRIPTION
Reverts the Terms of Service link in the footer to /tos, which is the correct routing path in App.tsx.