### PR TITLE
fix(web): modernize scripts and address security findings

### DIFF
--- a/.github/workflows/approve-renovate.yml
+++ b/.github/workflows/approve-renovate.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   approve:
-    if: github.actor == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,5 +1,5 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 const BASE_URL = 'https://flowlint.dev';
 const OUT_FILE = path.join(process.cwd(), 'public', 'sitemap.xml');
@@ -16,8 +16,7 @@ const routes = [
   '/tos',
 ];
 
-const generateSitemap = async () => {
-  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   ${routes
     .map((route) => {
@@ -32,8 +31,5 @@ const generateSitemap = async () => {
     .join('')}
 </urlset>`;
 
-  await fs.writeFile(OUT_FILE, sitemap.trim(), 'utf-8');
-  console.log(`Sitemap generated at ${OUT_FILE}`);
-};
-
-generateSitemap().catch(console.error);
+await fs.writeFile(OUT_FILE, sitemap.trim(), 'utf-8');
+console.log(`Sitemap generated at ${OUT_FILE}`);

--- a/scripts/generate-static-routes.ts
+++ b/scripts/generate-static-routes.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ESM compatibility for __dirname
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
Use node: prefix for built-in imports, apply top-level await, and secure Renovate workflow.